### PR TITLE
Corrections for pt_BR translation

### DIFF
--- a/locale/pt_BR/LC_MESSAGES/The Legend of Z.po
+++ b/locale/pt_BR/LC_MESSAGES/The Legend of Z.po
@@ -2099,8 +2099,10 @@ msgstr "Criar novo Tema"
 #, php-format
 msgid "Library description, %s, %s"
 msgstr ""
-"Aqui você encontrará todos os Temas da Biblioteca “%s” e as missões "
-"correspondentes. Seu progresso em “%s” afeta o tamanho da biblioteca."
+"Nesta página você encontrará todos os Temas do Seminário “%s” e todas"
+"as missões para verificar e tentar de novo. Seu progresso em “%s” afeta"
+"a Biblioteca. Então, jogue regularmente e destrave todo o conteúdo,"
+"Missão por Missão."
 
 #: views/html/library/index.tpl:13
 #, php-format


### PR DESCRIPTION
A correction for a pt_BR message that wasn't complete.
I reviewed the rest of the messages using the en_EN translation as reference, it looks good.